### PR TITLE
update readme to the current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ members.
 
 In order that the system can output a planet file or a history planet
 file in the same run, all of this is generated from the history
-tables. This means a minor adjustment to how the "current" planet is
+tables. This means a minor adjustment to how the [previous planet scrip](https://github.com/openstreetmap/planetdump) was
 written, with a filter which drops any non-current version of an
 element and any current version which is deleted.
 


### PR DESCRIPTION
I may be mistaken but from what I see now this repo is current.

BTW, is https://wiki.openstreetmap.org/wiki/Planet.osm

> Note that planet download have ways that reference nodes that are not in the same file.
> Due to performance reasons it isn't possibly to get a fully consistent snapshot of the database. Although the dump is run in a transaction, the isolation level required for a "snapshot"-style dump dramatically increases the running time

section now outdated?